### PR TITLE
Narrowed down packages involving snap to avoid side effects

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     - name: Remove snapd
       become: true
       ansible.builtin.apt:
-        name: snap*
+        name: snapd
         state: absent
 
     - name: Remove the directory /var/cache/snapd/


### PR DESCRIPTION
Currently the behaviour removes through apt packages named snap*, this may cause side effects removing packages which have nothing to do with snap itself (snapraid for example). 

The only packages that requires removal is snapd.